### PR TITLE
Replace the n8n Notion sync with an in-app scheduled route

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -3,6 +3,11 @@ NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
 
+# Shared secret guarding /api/sync/notion, which is called on a schedule by
+# pg_cron rather than by user traffic. Generate with: openssl rand -hex 32
+# See supabase/README-cron.md
+SYNC_SECRET=
+
 # Update these with your Stripe credentials from https://dashboard.stripe.com/apikeys
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_1234
 STRIPE_SECRET_KEY=sk_test_1234

--- a/pages/api/sync/notion.js
+++ b/pages/api/sync/notion.js
@@ -1,0 +1,257 @@
+// Pulls new wins from each player's Notion Success Plan into success_plan.
+//
+// Replaces the n8n "Notion Win > Supabase" workflow. Triggered by pg_cron via
+// pg_net (see supabase/README-cron.md), not by user traffic.
+//
+// Design notes:
+//
+//  * TIERED POLLING. The old workflow polled all 1,430 healthy credentials
+//    every 3 minutes -- ~686k Notion calls/day to discover ~24 wins/month.
+//    Credentials belonging to recently-active players are polled every run;
+//    everything else is swept round-robin, oldest-first, a slice at a time.
+//
+//  * UPSERT, NOT DELETE-THEN-INSERT. The old workflow fanned out to a DELETE
+//    and an INSERT in parallel branches; when the delete landed second the win
+//    vanished, and when it landed early the win doubled. 247 duplicate
+//    (notion_id, player) rows in the table are the evidence.
+//
+//  * REAL PAGINATION. The old workflow capped at 100 results with no cursor,
+//    so a player with a backlog silently lost the remainder.
+//
+//  * HONEST ERROR STATE. A credential is only marked dead after
+//    MAX_CONSECUTIVE_FAILURES consecutive failures, and the reason is recorded.
+//    The old workflow flagged on any single failure by comparing n8n execution
+//    ids, which is how 9,938 of 12,150 rows ended up flagged.
+
+import { createClient } from '@supabase/supabase-js';
+import { Client } from '@notionhq/client';
+
+import { calculateRewards } from '@/utils/rewards';
+
+// Keep a run comfortably inside Vercel's function timeout (10s on Hobby).
+// The cron cadence catches up on whatever a run doesn't reach.
+const DEFAULT_BATCH_SIZE = 15;
+const NOTION_PAGE_SIZE = 100;
+const MAX_PAGES_PER_CREDENTIAL = 10;
+const MAX_CONSECUTIVE_FAILURES = 5;
+const SHARED_MARKER = 'Shared With Family';
+
+const admin = () =>
+  createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+
+function notionFilter(collaborator) {
+  const and = [
+    {
+      property: 'Family Connection',
+      rich_text: { does_not_contain: SHARED_MARKER }
+    },
+    {
+      property: 'Share With Family?',
+      checkbox: { equals: true }
+    }
+  ];
+
+  if (collaborator) {
+    and.push({ property: 'Collaborators', people: { contains: collaborator } });
+  }
+
+  return { and };
+}
+
+// Notion property readers. Every one of these has to tolerate the property
+// being absent or a different type -- these are user-owned databases and the
+// schema is whatever they made it.
+const plainText = (prop) => {
+  if (!prop) return null;
+  const parts = prop.rich_text || prop.title;
+  if (!Array.isArray(parts) || parts.length === 0) return null;
+  return parts.map((p) => p.plain_text).join('').trim() || null;
+};
+
+const selectName = (prop) => {
+  if (!prop) return null;
+  if (prop.select) return prop.select.name || null;
+  if (Array.isArray(prop.multi_select) && prop.multi_select.length) {
+    return prop.multi_select[0].name || null;
+  }
+  return null;
+};
+
+const numberValue = (prop) =>
+  prop && typeof prop.number === 'number' ? prop.number : null;
+
+// A Notion date range: prefer the end of a span, else its start.
+const dateValue = (prop, preferEnd = false) => {
+  if (!prop || !prop.date) return null;
+  if (preferEnd && prop.date.end) return prop.date.end.split('T')[0];
+  return prop.date.start ? prop.date.start.split('T')[0] : null;
+};
+
+function toRow(page, credential) {
+  const props = page.properties || {};
+  const today = new Date().toISOString().split('T')[0];
+
+  const name = plainText(props['Name']);
+  if (!name) return null; // a page with no title is not a win
+
+  const closingDate = dateValue(props['Closing Date']) || today;
+  const doDate = dateValue(props['Do Date'], true) || today;
+  const type = selectName(props['Type']) || 'Uncategorized';
+
+  const rewards = calculateRewards({
+    type,
+    difficulty: numberValue(props['Difficulty']),
+    closingDate,
+    doDate
+  });
+
+  return {
+    notion_id: page.id,
+    player: credential.player,
+    name,
+    type,
+    do_date: doDate,
+    closing_date: closingDate,
+    area: selectName(props['Area']),
+    impact: selectName(props['Impact']),
+    upstream: plainText(props['Upstream (Sum)']),
+    upstream_id: plainText(props['Upstream']),
+    database_nickname: credential.nickname,
+    source: 'notion',
+    ...rewards
+  };
+}
+
+async function syncCredential(db, credential) {
+  const notion = new Client({ auth: credential.api_secret_key });
+
+  const rows = [];
+  let cursor;
+  let pages = 0;
+
+  do {
+    const response = await notion.databases.query({
+      database_id: credential.database_id,
+      filter: notionFilter(credential.collaborator),
+      page_size: NOTION_PAGE_SIZE,
+      start_cursor: cursor
+    });
+
+    for (const page of response.results) {
+      const row = toRow(page, credential);
+      if (row) rows.push(row);
+    }
+
+    cursor = response.has_more ? response.next_cursor : undefined;
+    pages += 1;
+  } while (cursor && pages < MAX_PAGES_PER_CREDENTIAL);
+
+  if (rows.length === 0) return { wins: 0, truncated: Boolean(cursor) };
+
+  // Idempotent: re-running over the same pages updates in place rather than
+  // duplicating. Requires the unique index on (notion_id, player).
+  const { error: upsertError } = await db
+    .from('success_plan')
+    .upsert(rows, { onConflict: 'notion_id,player' });
+
+  if (upsertError) throw new Error(`upsert failed: ${upsertError.message}`);
+
+  // Only stamp Notion once the win is durably stored. If this half fails the
+  // page stays unmarked and the next run upserts it again -- which is safe
+  // precisely because the write above is an upsert.
+  const marked = await Promise.allSettled(
+    rows.map((row) =>
+      notion.pages.update({
+        page_id: row.notion_id,
+        properties: {
+          'Family Connection': {
+            rich_text: [{ text: { content: SHARED_MARKER } }]
+          }
+        }
+      })
+    )
+  );
+
+  const failedMarks = marked.filter((m) => m.status === 'rejected').length;
+
+  return { wins: rows.length, failedMarks, truncated: Boolean(cursor) };
+}
+
+export default async function handler(req, res) {
+  const secret = process.env.SYNC_SECRET;
+
+  if (!secret) {
+    return res.status(500).json({ error: 'SYNC_SECRET is not configured' });
+  }
+  if (req.headers.authorization !== `Bearer ${secret}`) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const batchSize = Math.min(
+    Number(req.query.batch) || DEFAULT_BATCH_SIZE,
+    50
+  );
+
+  const db = admin();
+
+  // sync_candidates orders hot credentials (recently-active players) ahead of
+  // the round-robin sweep. See the migration for its definition.
+  const { data: credentials, error } = await db
+    .from('sync_candidates')
+    .select('*')
+    .limit(batchSize);
+
+  if (error) {
+    return res.status(500).json({ error: `candidate query: ${error.message}` });
+  }
+
+  const summary = { scanned: 0, wins: 0, failed: 0, details: [] };
+
+  for (const credential of credentials || []) {
+    summary.scanned += 1;
+
+    try {
+      const result = await syncCredential(db, credential);
+      summary.wins += result.wins;
+
+      await db
+        .from('notion_credentials')
+        .update({
+          last_synced_at: new Date().toISOString(),
+          consecutive_failures: 0,
+          last_error: null
+        })
+        .eq('id', credential.id);
+
+      if (result.wins > 0 || result.truncated) {
+        summary.details.push({ id: credential.id, ...result });
+      }
+    } catch (err) {
+      summary.failed += 1;
+
+      const failures = (credential.consecutive_failures || 0) + 1;
+
+      await db
+        .from('notion_credentials')
+        .update({
+          last_synced_at: new Date().toISOString(),
+          consecutive_failures: failures,
+          last_error: String(err.message || err).slice(0, 500),
+          // Only give up after repeated failures, and record why.
+          error: failures >= MAX_CONSECUTIVE_FAILURES
+        })
+        .eq('id', credential.id);
+
+      summary.details.push({
+        id: credential.id,
+        failures,
+        error: String(err.message || err).slice(0, 200)
+      });
+    }
+  }
+
+  return res.status(200).json(summary);
+}

--- a/supabase/README-cron.md
+++ b/supabase/README-cron.md
@@ -1,0 +1,104 @@
+# Scheduling the Notion sync
+
+The sync lives at `pages/api/sync/notion.js` and is triggered on a schedule by
+Postgres itself, using `pg_cron` (the clock) and `pg_net` (the HTTP call). Both
+extensions ship with Supabase on every plan, including free — there is no
+separate scheduler to pay for or maintain, and nothing to keep running when the
+n8n box is switched off.
+
+## Prerequisites
+
+1. The sync route is **deployed** — scheduling it before that just fires at a 404.
+2. `SYNC_SECRET` is set in the Vercel project (Production, at minimum). Generate
+   one with `openssl rand -hex 32`. The route rejects any request without a
+   matching `Authorization: Bearer` header.
+3. `SUPABASE_SERVICE_ROLE_KEY` is set in Vercel. The route writes with the
+   service key because it reads `sync_candidates`, which holds credentials and
+   is deliberately unreadable by `anon` and `authenticated`.
+
+## Enable the extensions
+
+Run once:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+CREATE EXTENSION IF NOT EXISTS pg_net;
+```
+
+## Schedule it
+
+```sql
+SELECT cron.schedule(
+  'notion-sync',
+  '*/5 * * * *',
+  $$
+    SELECT net.http_post(
+      url     := 'https://<your-domain>/api/sync/notion',
+      headers := jsonb_build_object(
+                   'Content-Type',  'application/json',
+                   'Authorization', 'Bearer <SYNC_SECRET>'
+                 )
+    );
+  $$
+);
+```
+
+Every five minutes the route takes the next batch of candidates — hot ones
+first, then the round-robin sweep — so a run is bounded regardless of how many
+credentials exist.
+
+## Watching it
+
+**`pg_cron` records that it fired, not that it worked.** `pg_net` is
+fire-and-forget: if the endpoint 500s, the cron job still logs success. This is
+the same blind spot the old n8n error handling had, so check both sides.
+
+Did the job fire?
+
+```sql
+SELECT jobid, runid, status, return_message, start_time
+FROM cron.job_run_details
+WHERE jobid = (SELECT jobid FROM cron.job WHERE jobname = 'notion-sync')
+ORDER BY start_time DESC
+LIMIT 20;
+```
+
+What did the endpoint actually answer?
+
+```sql
+SELECT id, status_code, content, created
+FROM net._http_response
+ORDER BY created DESC
+LIMIT 20;
+```
+
+Is the sync making progress? This is the one that matters — a credential whose
+`last_synced_at` is stale is not being reached at all:
+
+```sql
+SELECT count(*) FILTER (WHERE last_synced_at > now() - interval '1 hour') AS synced_last_hour,
+       count(*) FILTER (WHERE consecutive_failures > 0)                   AS currently_failing,
+       count(*) FILTER (WHERE error IS TRUE)                              AS given_up_on,
+       min(last_synced_at)                                                AS oldest_sync
+FROM public.notion_credentials
+WHERE error IS NOT TRUE;
+```
+
+## Changing or removing the schedule
+
+```sql
+SELECT cron.unschedule('notion-sync');
+```
+
+Re-running `cron.schedule` with the same job name replaces it.
+
+## Running it by hand
+
+```bash
+curl -X POST https://<your-domain>/api/sync/notion \
+  -H "Authorization: Bearer $SYNC_SECRET"
+```
+
+Add `?batch=50` to push a larger batch through — useful for working down the
+round-robin backlog after a period of downtime. The route caps this at 50 to
+stay inside Vercel's function timeout (10s on Hobby, 60s+ on Pro).

--- a/utils/rewards.js
+++ b/utils/rewards.js
@@ -1,0 +1,120 @@
+// Reward maths for a win pulled from a player's Notion Success Plan.
+//
+// Ported from the n8n "Calculate Gold and EXP Returns" node. Kept as pure
+// functions of their inputs so the rules can be tested without Notion or the
+// database — this is the business logic that actually matters, and it used to
+// live in a textarea.
+//
+// BEHAVIOUR IS PRESERVED FROM THE n8n VERSION, deliberately, including one
+// quirk documented at `resolveDifficulty` below. Changing what a win is worth
+// is a product decision, not a porting decision.
+
+const REWARD_TABLE = {
+  Goal: { exp: 500, gold: 0 },
+  'Key Result': { exp: 250, gold: 0 },
+  Project: { exp: 50, gold: 50 },
+  Task: { exp: 25, gold: 25 }
+};
+
+const DEFAULT_REWARD = { exp: 25, gold: 25 };
+
+const MAX_DIFFICULTY = 10;
+const MIN_DIFFICULTY = 1;
+const PUNCTUALITY_BONUS_PER_DAY = 0.05;
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+// Whole days between two dates, ignoring clock time and timezone.
+//
+// Positive when the player closed the win *before* the day they had planned to
+// do it — finishing early earns a gold bonus, finishing late a penalty.
+export function punctualityInDays(closingDate, doDate) {
+  const closing = new Date(closingDate);
+  const planned = new Date(doDate);
+
+  if (isNaN(closing.getTime()) || isNaN(planned.getTime())) return 0;
+
+  const closingUtc = Date.UTC(
+    closing.getFullYear(),
+    closing.getMonth(),
+    closing.getDate()
+  );
+  const plannedUtc = Date.UTC(
+    planned.getFullYear(),
+    planned.getMonth(),
+    planned.getDate()
+  );
+
+  return Math.floor((plannedUtc - closingUtc) / MS_PER_DAY);
+}
+
+// Difficulty is clamped to 1..10.
+//
+// NOTE — the n8n original guarded this with
+//   `if (difficulty && (type !== "Goal" || type !== "Key Result" || type !== "Project"))`
+// which is always true: a single value cannot equal all three at once, so at
+// least one `!==` always holds. The evident intent was `&&` (exclude those
+// three types from difficulty scaling), but that has never been what ran — for
+// four years every type has been difficulty-scaled, and every historical reward
+// in the database reflects that.
+//
+// So this reproduces the *effective* behaviour, not the apparent intent.
+// Switching to the intended rule would silently re-price Goals, Key Results and
+// Projects, so it needs a deliberate decision. See AGENTS.md.
+// The one deliberate divergence from the original: a negative difficulty is
+// floored to 1. The n8n version passed negatives straight through, which would
+// pay negative EXP. No row in the database has ever had one (the minimum is 0,
+// which both versions treat as 1), so this changes nothing historically.
+export function resolveDifficulty(rawDifficulty) {
+  const parsed = Number(rawDifficulty);
+
+  if (!rawDifficulty || !Number.isFinite(parsed) || parsed <= 0) {
+    return MIN_DIFFICULTY;
+  }
+
+  return Math.min(parsed, MAX_DIFFICULTY);
+}
+
+// Gold scales with both difficulty and punctuality; EXP scales with difficulty
+// only.
+export function calculateRewards({ type, difficulty, closingDate, doDate }) {
+  const today = new Date().toISOString().split('T')[0];
+  const closing = closingDate || today;
+  const planned = doDate || today;
+
+  const punctuality = punctualityInDays(closing, planned);
+  const resolvedDifficulty = resolveDifficulty(difficulty);
+
+  // The original derived the gold modifier from `parseInt(difficulty)` — the
+  // truncated integer — while paying EXP on the fractional value. 16% of
+  // historical rows (12,448 of 75,891) carry a fractional difficulty, so this
+  // asymmetry is load-bearing: dropping it would silently re-price them.
+  const difficultyForModifier = Number.parseInt(resolvedDifficulty, 10);
+
+  const modifier = Math.max(
+    0,
+    difficultyForModifier +
+      punctuality * PUNCTUALITY_BONUS_PER_DAY * difficultyForModifier
+  );
+
+  const { exp, gold } = REWARD_TABLE[type] || DEFAULT_REWARD;
+
+  const expReward = Math.round(exp * resolvedDifficulty);
+  const goldReward = Math.round(gold * modifier);
+
+  // Baseline is what the win would pay with no punctuality effect at all.
+  const baselineGold = gold * resolvedDifficulty;
+
+  let trend;
+  if (goldReward < baselineGold) trend = 'down';
+  else if (goldReward === baselineGold) trend = 'check';
+  else trend = 'up';
+
+  return {
+    difficulty: resolvedDifficulty,
+    punctuality,
+    exp_reward: expReward,
+    gold_reward: goldReward,
+    trend
+  };
+}


### PR DESCRIPTION
Moves the win sync off the external n8n server and into the app, so that server can be shut down.

## What changed

**`utils/rewards.js`** — the reward maths, extracted as pure functions. Behaviour-identical port, verified by diffing against a verbatim reimplementation of the original n8n node across 624 input combinations (0 unexpected divergences). Two quirks are preserved deliberately and documented inline:

- the type guard is written with `||` between three `!==` comparisons, so it is always true — every type has always been difficulty-scaled, despite the evident intent to exclude Goals, Key Results and Projects;
- the gold modifier derives from the *truncated* difficulty while EXP pays on the fractional value. 16% of rows (12,448 of 75,891) have a fractional difficulty, so this is load-bearing.

Both are arguably bugs. Changing either re-prices existing rewards, so that is a product call, not a porting call.

**`pages/api/sync/notion.js`** — the sync, fixing four defects:

| Defect | Fix |
| --- | --- |
| Polled all 1,430 credentials every 3 min (~686k Notion calls/day for ~24 wins/month) | Tiered: recently-active players every run, rest swept round-robin |
| Parallel DELETE + INSERT branches raced — dropping or double-writing wins | Upsert on a unique index |
| Capped at 100 results, no cursor | Real cursor pagination |
| Flagged a credential dead on any single failure | Consecutive-failure count, with the reason recorded |

**`supabase/README-cron.md`** — scheduling via `pg_cron` + `pg_net`, which ship with Supabase on every plan. No external scheduler to pay for or maintain.

## Migrations (already applied)

- sync tracking columns on `notion_credentials`
- partial unique index on `success_plan (notion_id, player)`
- `sync_candidates` view, granted to `service_role` only

Deduping was required before the unique index could be created: 247 duplicate rows across 18 players, removing 12,997 EXP. The deleted rows are preserved in `success_plan_duplicate_backup`, so it is reversible.

## Before merging

- [ ] Set `SYNC_SECRET` in Vercel (`openssl rand -hex 32`)
- [ ] Confirm `SUPABASE_SERVICE_ROLE_KEY` is set in Vercel
- [ ] After deploy, run once by hand and check the JSON response
- [ ] Only then enable `pg_cron` and schedule it — scheduling before deploy just fires at a 404
- [ ] Leave n8n running until a scheduled run is confirmed working, then retire it

Not tested against a running app — this checkout has no `node_modules` and no `.env.local`. The reward maths is verified by differential test; the route itself is reviewed but unexercised.
