### PR TITLE
Record applied party lifecycle migration + v.55 changelog

### DIFF
--- a/supabase/migrations/20260803100000_party_lifecycle_hygiene.sql
+++ b/supabase/migrations/20260803100000_party_lifecycle_hygiene.sql
@@ -1,0 +1,62 @@
+-- Party lifecycle hygiene, applied 2026-08-03. Three related changes:
+--
+-- 1. party_review reads narrowed to partymates. The old public SELECT let any
+--    anonymous API call read every reflection's free text ("what could I have
+--    done better") -- personal content per the repo's own access rules. The
+--    leaderboard views keep working: they run with definer rights.
+--
+-- 2. party_details also derives Complete for stale recruiting. Every party
+--    stuck in Recruiting was years past its due date and still advertised on
+--    the Join A Party board. The 7-day grace matters: a new party's due_date
+--    defaults to now(), so expiring at due_date exactly would complete a party
+--    the moment it was created.
+--
+-- 3. A daily cron job persists what the view derives, so the table stops
+--    drifting from what every surface displays. The 2-day gate for In
+--    Progress parties matches the leader's manual "Mark Challenge As
+--    Complete" button. Verified before scheduling: nothing in the app grants
+--    a completion reward on status 4, so this re-prices nothing.
+
+drop policy "Enable read access for all users" on public.party_review;
+
+create policy "Enable read for members of the same party"
+on public.party_review
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.party_members reviewed
+    join public.party_members me on me.party_id = reviewed.party_id
+    where reviewed.id = party_review.party_member
+      and me.player = (select auth.uid())
+  )
+);
+
+create or replace view public.party_details as
+ SELECT party.id,
+    party.name,
+    party.challenge,
+    party.description,
+    party.due_date,
+        CASE
+            WHEN ((now() >= party.due_date) AND (party.status = 2)) THEN (3)::bigint
+            WHEN ((now() >= (party.due_date + interval '7 days')) AND (party.status = 1)) THEN (4)::bigint
+            ELSE party.status
+        END AS status,
+    party.slug,
+    party.daily_target,
+    party.created_on,
+    party.start_date,
+    party.created_by
+   FROM party;
+
+select cron.schedule(
+  'complete-overdue-parties',
+  '23 3 * * *',
+  $$
+    UPDATE public.party SET status = 4
+    WHERE (status = 2 AND due_date + interval '2 days' <= now())
+       OR (status = 1 AND due_date + interval '7 days' <= now());
+  $$
+);

--- a/utils/updates.json
+++ b/utils/updates.json
@@ -1,5 +1,13 @@
 [
   {
+  "date": "Aug 4, 2026",
+  "title": "Party Quests Are Back In Action",
+  "desc": "We've fixed up party quests from top to bottom. Creating a party, joining one, and reflecting after a challenge all work reliably again - and finished parties now wrap up on their own instead of lingering on the recruitment board forever.",
+  "desc2": "The board has been swept clean, so the next party you see recruiting is really recruiting. Level 10+ adventurers, it's a great day to start one!",
+  "button_url": "/parties",
+  "version": "55"
+  },
+  {
   "date": "Jun 20, 2023",
   "title": "Embark On Missions",
   "desc": "Level up and earn your very own adventurer card by going on missions to make positive impact on the world.",


### PR DESCRIPTION
Two commits: (1) records the SQL already applied to production on 2026-08-03 - party_review write policy for the reviewing member, reads narrowed to partymates, party_details deriving Complete for recruiting parties 7+ days past due, and the daily complete-overdue-parties cron job; (2) adds the v.55 changelog entry announcing the parties fixes, which also bumps the footer version badge.